### PR TITLE
Redesigned the release pipeline to auto cross-compile for architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+# Author: K4YT3X <i@k4yt3x.com>
+# Cross-compiles dvmhost and dvmcmd for all architectures upon pushing a new tag.
+
+name: dvmhost-build-release
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      APPNAME: ${{ steps.get_appname.outputs.APPNAME }}
+      VERSION: ${{ steps.get_version.outputs.VERSION }}
+    steps:
+      - name: Get app name
+        id: get_appname
+        run: echo ::set-output name=APPNAME::${{ github.event.repository.name }}
+      - name: Get version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+  create-release:
+    needs:
+      - setup
+    name: Create Relase
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.setup.outputs.VERSION }}
+          release_name: Release ${{ needs.setup.outputs.VERSION }}
+          draft: true
+          prerelease: false
+
+  ubuntu:
+    strategy:
+      matrix:
+        arch: ["AMD64", "ARM", "AARCH64", "RPI_ARM"]
+    needs: [setup, create-release]
+    runs-on: ubuntu-latest
+    env:
+      PACKAGENAME: ${{ needs.setup.outputs.APPNAME }}-${{ needs.setup.outputs.VERSION }}-${{ matrix.arch }}
+      DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.setup.outputs.VERSION }}
+          submodules: recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y git build-essential cmake g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf g++-aarch64-linux-gnu
+          sudo git clone --recurse-submodules https://github.com/raspberrypi/tools.git /opt/tools
+      - name: Build
+        run: |
+          sed -i 's/3.18.4/3.16.3/g' CMakeLists.txt
+          cmake -DENABLE_DMR=1 -DENABLE_P25=1 -DENABLE_NXDN=1 -DCROSS_COMPILE_${{ matrix.arch }}=1 .
+          make
+      - name: Package
+        run: |
+          mkdir -p ${{ env.PACKAGENAME }}
+          cp dvmcmd dvmhost ${{ env.PACKAGENAME }}
+          zip -9 -r ${{ env.PACKAGENAME }}.zip ${{ env.PACKAGENAME }}
+      - name: Upload
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.PACKAGENAME }}.zip
+          asset_name: ${{ env.PACKAGENAME }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
-          sudo apt-get install -y git build-essential cmake g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf g++-aarch64-linux-gnu
+          sudo apt-get install -y git build-essential cmake g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf g++-aarch64-linux-gnu libasio-dev
           sudo git clone --recurse-submodules https://github.com/raspberrypi/tools.git /opt/tools
       - name: Build
         run: |


### PR DESCRIPTION
I see that the current dvmhost doesn't have a full pipeline that could cross-compile the binary for all platforms and put the compiled binaries in a release draft. I've created a pipeline [here](https://github.com/northern-trunked/dvmhost-compiled) for our trunked radio project, but I thought it might be helpful to contribute this to the upstream so everyone coming here can just download the pre-build binaries.

Instructions for building new releases can be found [here](https://github.com/northern-trunked/dvmhost-compiled). Basically it'll create a new release whenever you create a new tag (like the `2023-03-01` you just created. You can find an example of what the release would look like on [this page](https://github.com/k4yt3x/dvmhost/releases/tag/2023-03-02). You can see that I've already tested this pipeline in my own fork and it works fine.

Lmk if you have any questions.

## Screenshots

![image](https://user-images.githubusercontent.com/21986859/222290601-399a31a3-fc49-4484-847e-d927f2f076d4.png)

![image](https://user-images.githubusercontent.com/21986859/222290626-afcbe572-74d2-41b2-b55b-afe8a98c6521.png)
