### PR TITLE
Fixed release pipeline for RPI_ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
     steps:
       - name: Get app name
         id: get_appname
-        run: echo ::set-output name=APPNAME::${{ github.event.repository.name }}
+        run: echo APPNAME=${{ github.event.repository.name }} >> $GITHUB_OUTPUT
       - name: Get version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo VERSION=${GITHUB_REF/refs\/tags\//} >> $GITHUB_OUTPUT
 
   create-release:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,24 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
-          sudo apt-get install -y git build-essential cmake g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf g++-aarch64-linux-gnu libasio-dev
+          sudo apt-get install -y git build-essential cmake \
+            g++-arm-linux-gnueabihf \
+            gcc-arm-linux-gnueabihf \
+            g++-aarch64-linux-gnu \
+            libasio-dev
           sudo git clone --recurse-submodules https://github.com/raspberrypi/tools.git /opt/tools
       - name: Build
         run: |
-          sed -i 's/3.18.4/3.16.3/g' CMakeLists.txt
-          cmake -DENABLE_DMR=1 -DENABLE_P25=1 -DENABLE_NXDN=1 -DCROSS_COMPILE_${{ matrix.arch }}=1 .
+          if [[ "${{ matrix.arch }}" == "RPI_ARM" ]]; then
+            sudo sed -i 's/^# deb-src/deb-src/g' /etc/apt/sources.list
+            sudo apt-get update
+            sudo apt-get source asio
+            cmake -DENABLE_DMR=1 -DENABLE_P25=1 -DENABLE_NXDN=1 -DCROSS_COMPILE_${{ matrix.arch }}=1 \
+              -DWITH_ASIO="$(realpath -e $(find . -maxdepth 1 -type d -iname 'asio*'))" .
+          else
+            cmake -DENABLE_DMR=1 -DENABLE_P25=1 -DENABLE_NXDN=1 -DCROSS_COMPILE_${{ matrix.arch }}=1 .
+          fi
+
           make
       - name: Package
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,10 @@ jobs:
     steps:
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ needs.setup.outputs.VERSION }}
-          release_name: Release ${{ needs.setup.outputs.VERSION }}
+          name: Release ${{ needs.setup.outputs.VERSION }}
           draft: true
           prerelease: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@
 #*   along with this program; if not, write to the Free Software
 #*   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 #*/
-cmake_minimum_required(VERSION 3.18.4)
+cmake_minimum_required(VERSION 3.16.0)
 
 # dvmhost source/header files
 file(GLOB dvmhost_SRC


### PR DESCRIPTION
Aside from fixing the pipeline so it can compile RPI_ARM arch properly, I've also replaced a few deprecated components with newer maintained ones. The required CMake version has been lowered to 3.16.0 since it seems this requirement is sufficient for compiling the binary and is supported my more environments such as Ubuntu 20.04 and GHA's runner.

