### PR TITLE
fixed REST API accept permit-tg failure

### DIFF
--- a/src/network/RESTAPI.cpp
+++ b/src/network/RESTAPI.cpp
@@ -783,7 +783,7 @@ void RESTAPI::restAPI_PutPermitTG(const HTTPPayload& request, HTTPPayload& reply
 
     errorPayload(reply, "OK", HTTPPayload::OK);
 
-    if (!m_host->m_authoritative) {
+    if (m_host->m_authoritative) {
         errorPayload(reply, "Host is authoritative, cannot permit TG");
         return;
     }

--- a/src/p25/Control.cpp
+++ b/src/p25/Control.cpp
@@ -772,7 +772,7 @@ void Control::clock(uint32_t ms)
 /// <param name="dstId"></param>
 void Control::permittedTG(uint32_t dstId)
 {
-    if (!m_authoritative) {
+    if (m_authoritative) {
         return;
     }
 


### PR DESCRIPTION
I figured out what's wrong with the permit-tg issue. After your last patch the CC started sending traffic to the VC when I key up, but the VC returns an error:

![image](https://user-images.githubusercontent.com/21986859/227766017-4a674a82-499c-4e22-a168-0b4b8f8f95b9.png)

So I traced this and made the fix in `network/RESTAPI.cpp`. However that still didn't fix it. The VC was still showing "[NON-AUTHORITATIVE] Ignoring RF traffic, destination not permitted!" so i traced it back into `p25/Control.cpp` and found another inverted boolean check and fixed that too. Now it works and I can transmit just fine.