### PR TITLE
made incoming traffic update P25 channel grant timer to fix embedded STC

### DIFF
--- a/src/p25/Control.cpp
+++ b/src/p25/Control.cpp
@@ -1056,13 +1056,7 @@ void Control::processNetwork()
         case P25_DUID_HDU:
         case P25_DUID_LDU1:
         case P25_DUID_LDU2:
-            if (!m_dedicatedControl)
-                ret = m_voice->processNetwork(data, length, control, lsd, duid, frameType);
-            else {
-                if (m_voiceOnControl) {
-                    ret = m_voice->processNetwork(data, length, control, lsd, duid, frameType);
-                }
-            }
+            ret = m_voice->processNetwork(data, length, control, lsd, duid, frameType);
             break;
 
         case P25_DUID_TDU:


### PR DESCRIPTION
Issue: when embedded STC (supervisor) is turned on, the CC will sometimes revoke the channel grant, causing the VC to stop sending traffic even if there's incoming traffic playing on the VC. To fix this, I've updated it so the incoming LDU frames will refresh the grant timer, preventing the grant from getting dropped while the channel is still active. This might need to be done for other types of traffic as well.

I've also fixed the bug where LDU2 doesn't care if a grant exists for the channel.

I've tested it, I'm no longer experimenting traffic interruptions after this fix.