### PR TITLE
Fixed the command in README for adding dtoverlay=disable-bt into the boot config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ _deps
 # Ignore thumbnails created by windows
 Thumbs.db
 
+# Ignore files created by clang-check
+*.plist
+
 # Ignore files build by Visual Studio
 *.obj
 *.pdb

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The steps above can be done by the following commands:
 
 ```shell
 sudo systemctl disable bluetooth.service serial-getty@ttyAMA0.service
-grep -E 'dtoverlay=disable-bt' /boot/config.txt || echo 'dtoverlay=disable-bt' | sudo tee /boot/config.txt
+grep '^dtoverlay=disable-bt' /boot/config.txt || echo 'dtoverlay=disable-bt' | sudo tee -a /boot/config.txt
 sudo sed -i 's/^console=serial0,115200 *//' /boot/cmdline.txt
 ```
 


### PR DESCRIPTION
Somehow made a mistake with the command. It'll replace the file instead of appending to it. I tested the commands before committing, not sure how I missed this.

Also added an ignore for clang-check because it's spamming my git status.