### PR TITLE
Temporarily disabled TUI support in pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,9 @@ on:
   workflow_dispatch:
     inputs:
       buildType:
-        description: 'CMake Build Type'
+        description: "CMake Build Type"
         required: true
-        default: 'Release'
+        default: "Release"
         type: choice
         options:
           - Release
@@ -15,7 +15,7 @@ on:
           - RelWithDebInfo
           - MinSizeRel
       stripSymbols:
-        description: 'Strip Symbols'
+        description: "Strip Symbols"
         required: false
         type: boolean
   push:
@@ -60,6 +60,7 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y git build-essential cmake \
             g++-arm-linux-gnueabihf \
             gcc-arm-linux-gnueabihf \
@@ -67,13 +68,14 @@ jobs:
             libasio-dev
       - name: Build
         run: |
+          build_args='-DENABLE_TUI_SUPPORT=0'
           if [[ "${{ github.event_name }}" == 'push' ]]; then
-            build_args="-DCMAKE_BUILD_TYPE=${{ inputs.buildType }}"
+            build_args="$build_args -DCMAKE_BUILD_TYPE=${{ inputs.buildType }}"
             if [[ "${{ inputs.stripSymbols }}" == 'true' ]]; then
               build_args="$build_args -DCMAKE_C_FLAGS='-s' -DCMAKE_CXX_FLAGS='-s'"
             fi
           else
-            build_args='-DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s"'
+            build_args="$build_args -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS='-s' -DCMAKE_CXX_FLAGS='-s'"
           fi
 
           if [[ "${{ matrix.arch }}" == 'armhf' ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           submodules: recursive
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y git build-essential cmake \
             g++-arm-linux-gnueabihf \
             gcc-arm-linux-gnueabihf \
@@ -52,9 +53,11 @@ jobs:
         run: |
           if [[ "${{ matrix.arch }}" == 'armhf' ]]; then
             cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s" \
+              -DENABLE_TUI_SUPPORT=0 \
               -DCROSS_COMPILE_RPI_ARM=1 .
           else
             cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s" \
+              -DENABLE_TUI_SUPPORT=0 \
               -D "CROSS_COMPILE_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')=1" .
           fi
 


### PR DESCRIPTION
While building with TUI support works for other architectures, it doesn't for `armhf`. Before I figure out how to fix it for the older toolchain, merge this so the build pipeline stops failing.