### PR TITLE
Adding CORS headers to the REST api

### DIFF
--- a/src/network/rest/RequestDispatcher.h
+++ b/src/network/rest/RequestDispatcher.h
@@ -156,6 +156,12 @@ namespace network
                             }
 
                             //what = matcher.first;
+
+                            // ensure CORS headers are added
+                            reply.headers.add("Access-Control-Allow-Origin", "*");
+                            reply.headers.add("Access-Control-Allow-Methods", "*");
+                            reply.headers.add("Access-Control-Allow-Headers", "*");
+                            
                             matcher.second->handleRequest(request, reply, what);
                             return;
                         }

--- a/src/network/rest/RequestDispatcher.h
+++ b/src/network/rest/RequestDispatcher.h
@@ -158,9 +158,14 @@ namespace network
                             //what = matcher.first;
 
                             // ensure CORS headers are added
+                            
                             reply.headers.add("Access-Control-Allow-Origin", "*");
                             reply.headers.add("Access-Control-Allow-Methods", "*");
                             reply.headers.add("Access-Control-Allow-Headers", "*");
+                            
+                            if (request.method == HTTP_OPTIONS) {
+                                reply.status = http::HTTPPayload::OK;
+                            }
                             
                             matcher.second->handleRequest(request, reply, what);
                             return;


### PR DESCRIPTION
I'm working on an upcoming web-based dispatch console app for DVM.
This PR adds the required CORS headers to the API responses to allow modern browsers to pull data from the API.

We could probably make this a bit cleaner in the future by adding config options for what domains to allow requests from, but this will at the very least get things moving.