### PR TITLE
set shortened full-rate voice frame length to 14 bytes

### DIFF
--- a/src/dfsi/frames/MotFullRateVoice.h
+++ b/src/dfsi/frames/MotFullRateVoice.h
@@ -54,7 +54,7 @@ namespace p25
         class HOST_SW_API MotFullRateVoice {
         public:
             static const uint8_t LENGTH = 17;
-            static const uint8_t SHORTENED_LENGTH = 13;
+            static const uint8_t SHORTENED_LENGTH = 14;
             static const uint8_t ADDITIONAL_LENGTH = 4;
 
             /**


### PR DESCRIPTION
Shortened IMBE frames (LDU1 F2 $63 and LDU2 F11 $6C) should have 14 bytes (based on testing).  Tested on 2 different DIUs and a Quantar.  This fixes the DIU RX audio issue.

Note: this does not fix the DIU TX issues as the DIU uses a different Start ICW format than the Quantars.