### PR TITLE
Add DVM-V24 Firmware Submodule And Enable Building It

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "src/fw/hotspot"]
 	path = src/fw/hotspot
 	url = https://github.com/DVMProject/dvmfirmware-hs.git
+[submodule "src/fw/v24"]
+	path = src/fw/v24
+	url = https://github.com/dvmproject/dvmv24.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,10 @@ if (NOT TARGET tarball)
             COMMAND if [ -e dvm-firmware_due.bin ]\; then cp -v dvm-firmware_due.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND if [ -e dvm-firmware-hs_f1.elf ]\; then cp -v dvm-firmware-hs_f1.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND if [ -e dvm-firmware-hs_f1.bin ]\; then cp -v dvm-firmware-hs_f1.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.elf ]\; then cp -v DVM-V24-stm32f103.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.bin ]\; then cp -v DVM-V24-stm32f103.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.hex ]\; then cp -v DVM-V24-stm32f103.hex ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.map ]\; then cp -v DVM-V24-stm32f103.map ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND cd ${CMAKE_INSTALL_PREFIX_TARBALL} && tar czvf ../dvmhost_${CPACK_DEBIAN_PACKAGE_VERSION}_${ARCH}.tar.gz *
             COMMAND rm -rf ${CMAKE_INSTALL_PREFIX_TARBALL})
     else()
@@ -362,6 +366,10 @@ if (NOT TARGET tarball)
             COMMAND if [ -e dvm-firmware_due.bin ]\; then cp -v dvm-firmware_due.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND if [ -e dvm-firmware-hs_f1.elf ]\; then cp -v dvm-firmware-hs_f1.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND if [ -e dvm-firmware-hs_f1.bin ]\; then cp -v dvm-firmware-hs_f1.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.elf ]\; then cp -v DVM-V24-stm32f103.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.bin ]\; then cp -v DVM-V24-stm32f103.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.hex ]\; then cp -v DVM-V24-stm32f103.hex ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+            COMMAND if [ -e DVM-V24-stm32f103.map ]\; then cp -v DVM-V24-stm32f103.map ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
             COMMAND cd ${CMAKE_INSTALL_PREFIX_TARBALL} && tar czvf ../dvmhost_${CPACK_DEBIAN_PACKAGE_VERSION}_${ARCH}.tar.gz *
             COMMAND rm -rf ${CMAKE_INSTALL_PREFIX_TARBALL})
     endif (ENABLE_TUI_SUPPORT AND (NOT DISABLE_MONITOR))
@@ -409,6 +417,10 @@ add_custom_target(old_install
     COMMAND if [ -e dvm-firmware_due.bin ]\; then install -m 644 dvm-firmware_due.bin ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware_due.bin\; fi
     COMMAND if [ -e dvm-firmware-hs_f1.elf ]\; then install -m 644 dvm-firmware-hs_f1.elf ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware-hs_f1.elf\; fi
     COMMAND if [ -e dvm-firmware-hs_f1.bin ]\; then install -m 644 dvm-firmware-hs_f1.bin ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware-hs_f1.bin\; fi)
+    COMMAND if [ -e DVM-V24-stm32f103.elf ]\; then cp -v DVM-V24-stm32f103.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+    COMMAND if [ -e DVM-V24-stm32f103.bin ]\; then cp -v DVM-V24-stm32f103.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+    COMMAND if [ -e DVM-V24-stm32f103.hex ]\; then cp -v DVM-V24-stm32f103.hex ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+    COMMAND if [ -e DVM-V24-stm32f103.map ]\; then cp -v DVM-V24-stm32f103.map ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
 
 #
 # Custom make target to perform non-standard legacy service install. This is meant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,13 +500,15 @@ add_custom_target(dvmfw-stm32fx-clean
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/hotspot
 )
 add_custom_target(dvmfw-v24
-    COMMAND make -f Makefile clean
     COMMAND make -f Makefile
-    COMMAND rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw/Build
+    COMMAND cp DVM-V24-stm32f103.elf ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND cp DVM-V24-stm32f103.bin ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND cp DVM-V24-stm32f103.hex ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND cp DVM-V24-stm32f103.map ${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw
 )
 add_custom_target(dvmfw-v24-clean
-    COMMAND make -f Makefile clean
     COMMAND rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw/Build
+    COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/DVM-V24*
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,11 +436,11 @@ add_custom_target(old_install-service
 # Firmware compilation
 #
 add_custom_target(dvmfw
-    DEPENDS dvmfw-stm32f4 dvmfw-stm32f4-pog dvmfw-stm32f4-eda dvmfw-stm32f4-dvmv1 dvmfw-stm32fx
+    DEPENDS dvmfw-stm32f4 dvmfw-stm32f4-pog dvmfw-stm32f4-eda dvmfw-stm32f4-dvmv1 dvmfw-stm32fx dvm-v24
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/modem
 )
 add_custom_target(dvmfw-clean
-    DEPENDS dvmfw-stm32f4-clean dvmfw-stm32fx-clean
+    DEPENDS dvmfw-stm32f4-clean dvmfw-stm32fx-clean dvm-v24-clean
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/modem
 )
 
@@ -498,4 +498,15 @@ add_custom_target(dvmfw-stm32fx-clean
     COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/dvm-firmware*.elf
     COMMAND rm -f ${CMAKE_CURRENT_BINARY_DIR}/dvm-firmware*.bin
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/hotspot
+)
+add_custom_target(dvmfw-v24
+    COMMAND make -f Makefile clean
+    COMMAND make -f Makefile
+    COMMAND rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw/Build
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw
+)
+add_custom_target(dvmfw-v24-clean
+    COMMAND make -f Makefile clean
+    COMMAND rm -rf ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw/Build
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src/fw/v24/fw
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -416,11 +416,11 @@ add_custom_target(old_install
     COMMAND if [ -e dvm-firmware_due.elf ]\; then install -m 644 dvm-firmware_due.elf ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware_due.elf\; fi
     COMMAND if [ -e dvm-firmware_due.bin ]\; then install -m 644 dvm-firmware_due.bin ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware_due.bin\; fi
     COMMAND if [ -e dvm-firmware-hs_f1.elf ]\; then install -m 644 dvm-firmware-hs_f1.elf ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware-hs_f1.elf\; fi
-    COMMAND if [ -e dvm-firmware-hs_f1.bin ]\; then install -m 644 dvm-firmware-hs_f1.bin ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware-hs_f1.bin\; fi)
+    COMMAND if [ -e dvm-firmware-hs_f1.bin ]\; then install -m 644 dvm-firmware-hs_f1.bin ${CMAKE_LEGACY_INSTALL_PREFIX}/fw/dvm-firmware-hs_f1.bin\; fi
     COMMAND if [ -e DVM-V24-stm32f103.elf ]\; then cp -v DVM-V24-stm32f103.elf ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
     COMMAND if [ -e DVM-V24-stm32f103.bin ]\; then cp -v DVM-V24-stm32f103.bin ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
     COMMAND if [ -e DVM-V24-stm32f103.hex ]\; then cp -v DVM-V24-stm32f103.hex ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
-    COMMAND if [ -e DVM-V24-stm32f103.map ]\; then cp -v DVM-V24-stm32f103.map ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi
+    COMMAND if [ -e DVM-V24-stm32f103.map ]\; then cp -v DVM-V24-stm32f103.map ${CMAKE_INSTALL_PREFIX_TARBALL}/dvm/fw\; fi)
 
 #
 # Custom make target to perform non-standard legacy service install. This is meant


### PR DESCRIPTION
Now that DFSI has been rolled into host, it made sense to bring in the v24 board's firmware as a submodule, just as we do for modem and hotspot firmwares.