### PR TITLE
fixed calcTxOffset to use a signed integer;

### DIFF
--- a/src/host/Host.Config.cpp
+++ b/src/host/Host.Config.cpp
@@ -170,7 +170,7 @@ bool Host::readParams()
         float calcTxOffset = entry.txOffsetMhz() * 1000000.0;
 
         m_txFrequency = (uint32_t)((entry.baseFrequency() + ((calcSpace * 125) * m_channelNo)));
-        m_rxFrequency = (uint32_t)(m_txFrequency + (uint32_t)calcTxOffset);
+        m_rxFrequency = (uint32_t)(m_txFrequency + (int32_t)calcTxOffset);
 
         if (calcTxOffset < 0.0f && m_rxFrequency < entry.baseFrequency()) {
             ::LogWarning(LOG_HOST, "Channel Id %u Channel No $%04X has an invalid frequency. Rx Frequency (%u) is less then the base frequency (%u), this may result in incorrect trunking behavior.", m_channelId, m_channelNo,


### PR DESCRIPTION
(uint32_t)calcTxOffset would result in the offset being 0 if the value was negative in iden_table.dat