### PR TITLE
Implement override of default RTS/DTR behavior for DVM-V24-V2 boards with hardware boot control.

### DIFF
--- a/src/host/Host.Config.cpp
+++ b/src/host/Host.Config.cpp
@@ -552,12 +552,17 @@ bool Host::createModem()
         }
 
         if (portType == PTY_PORT) {
-            modemPort = new port::UARTPort(uartPort, serialSpeed, false);
+            modemPort = new port::UARTPort(uartPort, serialSpeed, false, false);
             LogInfo("    PTY Port: %s", uartPort.c_str());
             LogInfo("    PTY Speed: %u", uartSpeed);
         }
         else {
-            modemPort = new port::UARTPort(uartPort, serialSpeed, true);
+            if (modemMode == MODEM_MODE_DFSI) {
+                modemPort = new port::UARTPort(uartPort, serialSpeed, false, true);
+                LogInfo("    RTS/DTR boot flags enabled");
+            } else {
+                modemPort = new port::UARTPort(uartPort, serialSpeed, true, false);
+            }
             LogInfo("    UART Port: %s", uartPort.c_str());
             LogInfo("    UART Speed: %u", uartSpeed);
         }

--- a/src/host/modem/port/PseudoPTYPort.cpp
+++ b/src/host/modem/port/PseudoPTYPort.cpp
@@ -30,7 +30,7 @@ using namespace modem::port;
 
 /* Initializes a new instance of the PseudoPTYPort class. */
 
-PseudoPTYPort::PseudoPTYPort(const std::string& symlink, SERIAL_SPEED speed, bool assertRTS) : UARTPort(speed, assertRTS),
+PseudoPTYPort::PseudoPTYPort(const std::string& symlink, SERIAL_SPEED speed, bool assertRTS) : UARTPort(speed, assertRTS, false),
     m_symlink(symlink)
 {
     /* stub */

--- a/src/host/modem/port/UARTPort.h
+++ b/src/host/modem/port/UARTPort.h
@@ -76,7 +76,7 @@ namespace modem
              * @param speed Serial port speed.
              * @param assertRTS 
              */
-            UARTPort(const std::string& device, SERIAL_SPEED speed, bool assertRTS = false);
+            UARTPort(const std::string& device, SERIAL_SPEED speed, bool assertRTS = false, bool rtsBoot = false);
             /**
              * @brief Finalizes a instance of the UARTPort class.
              */
@@ -122,13 +122,14 @@ namespace modem
              * @param speed Serial port speed.
              * @param assertRTS 
              */
-            UARTPort(SERIAL_SPEED speed, bool assertRTS = false);
+            UARTPort(SERIAL_SPEED speed, bool assertRTS = false, bool rtsBoot = false);
 
             bool m_isOpen;
 
             std::string m_device;
             SERIAL_SPEED m_speed;
             bool m_assertRTS;
+            bool m_rtsBoot;
 #if defined(_WIN32)
             HANDLE m_fd;
 #else

--- a/src/host/setup/HostSetup.cpp
+++ b/src/host/setup/HostSetup.cpp
@@ -811,7 +811,6 @@ bool HostSetup::createModem(bool consoleDisplay)
         modemPort = new port::UARTPort(uartPort, serialSpeed, true);
         LogInfo("    UART Port: %s", uartPort.c_str());
         LogInfo("    UART Speed: %u", uartSpeed);
-        LogInfo("    Assert RTS enabled");
     }
 
     LogInfo("    RX Invert: %s", rxInvert ? "yes" : "no");

--- a/src/host/setup/HostSetup.cpp
+++ b/src/host/setup/HostSetup.cpp
@@ -811,6 +811,7 @@ bool HostSetup::createModem(bool consoleDisplay)
         modemPort = new port::UARTPort(uartPort, serialSpeed, true);
         LogInfo("    UART Port: %s", uartPort.c_str());
         LogInfo("    UART Speed: %u", uartSpeed);
+        LogInfo("    Assert RTS enabled");
     }
 
     LogInfo("    RX Invert: %s", rxInvert ? "yes" : "no");


### PR DESCRIPTION
DVM-V24-V2 boards have optional hardware boot control, using the CP2102 RTS/DTR signals for BOOT0/RESET respectively. This allows for entering UART boot mode even with a totally corrupted program so you can recover a board without the need for an ST-Link.

Currently in dvmhost (and in most linux terminal applications in general) RTS and DTR are both forced active, which results in the V24 board receiving a valid command to enter UART bootloader mode. These changes override the default behavior and force RTS off, while also sending a second DTR reset pulse. See the scope capture below (BOOT0 is yellow, /RESET is pink).

![image](https://github.com/user-attachments/assets/fbffb005-7829-4638-adee-f3700ef238d0)

Ideally, we would avoid the initial RTS & DTR pulses altogether, but there does not appear to be an easy way to achieve this with the current serial implementation.