### PR TITLE
Add TUI support for arm and arm64 in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,11 +157,10 @@ jobs:
         with:
           name: ${{ needs.setup.outputs.APPNAME }}-${{ matrix.arch }}
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.PACKAGENAME }}.tar.gz
-          asset_name: ${{ env.PACKAGENAME }}.tar.gz
-          asset_content_type: application/gzip
+          tag_name: ${{ needs.setup.outputs.DATE }}
+          files: ${{ env.PACKAGENAME }}.tar.gz
+          append_body: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
     needs: [setup]
     strategy:
       matrix:
-#        arch: ["amd64", "arm", "aarch64"]
         arch: ["amd64", "arm", "aarch64", "armhf"]
     runs-on: ubuntu-22.04
     env:
@@ -63,18 +62,36 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+      - name: Setup architecture support
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo dpkg --add-architecture arm64
+          echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list
+          echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y git build-essential cmake \
             g++-arm-linux-gnueabihf \
             gcc-arm-linux-gnueabihf \
-            g++-aarch64-linux-gnu \
-            libasio-dev libssl-dev libncurses-dev
+            g++-aarch64-linux-gnu
+
+          if [[ "${{ matrix.arch }}" == 'aarch64' ]]; then
+            sudo apt-get install -y libasio-dev:arm64 libssl-dev:arm64 libncurses-dev:arm64
+          elif [[ "${{ matrix.arch }}" == 'arm' ]]; then
+            sudo apt-get install -y libasio-dev:armhf libssl-dev:armhf libncurses-dev:armhf
+          elif [[ "${{ matrix.arch }}" == 'armhf' ]]; then
+            sudo apt-get install -y libasio-dev:armhf libssl-dev:armhf
+          else
+            sudo apt-get install -y libasio-dev libssl-dev libncurses-dev
+          fi
       - name: Build
         run: |
           build_args=''
-          if [[ "${{ matrix.arch }}" == 'amd64' ]]; then
+          if [[ "${{ matrix.arch }}" == 'amd64' || "${{ matrix.arch }}" == 'arm' || "${{ matrix.arch }}" == 'aarch64' ]]; then
             build_args='-DENABLE_TUI_SUPPORT=1'
           else
             build_args='-DENABLE_TUI_SUPPORT=0'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,30 +41,47 @@ jobs:
         with:
           ref: ${{ needs.setup.outputs.VERSION }}
           submodules: recursive
+      - name: Setup architecture support
+        run: |
+          sudo dpkg --add-architecture armhf
+          sudo dpkg --add-architecture arm64
+          echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy main restricted universe multiverse" | sudo tee /etc/apt/sources.list
+          echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports jammy main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          echo "deb [arch=armhf,arm64] http://ports.ubuntu.com/ubuntu-ports jammy-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y git build-essential cmake \
             g++-arm-linux-gnueabihf \
             gcc-arm-linux-gnueabihf \
-            g++-aarch64-linux-gnu \
-            libasio-dev libssl-dev libncurses-dev
+            g++-aarch64-linux-gnu
+
+          if [[ "${{ matrix.arch }}" == 'aarch64' ]]; then
+            sudo apt-get install -y libasio-dev:arm64 libssl-dev:arm64 libncurses-dev:arm64
+          elif [[ "${{ matrix.arch }}" == 'arm' ]]; then
+            sudo apt-get install -y libasio-dev:armhf libssl-dev:armhf libncurses-dev:armhf
+          elif [[ "${{ matrix.arch }}" == 'armhf' ]]; then
+            sudo apt-get install -y libasio-dev:armhf libssl-dev:armhf
+          else
+            sudo apt-get install -y libasio-dev libssl-dev libncurses-dev
+          fi
       - name: Build
         run: |
-          if [[ "${{ matrix.arch }}" == 'armhf' ]]; then
-            cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s" \
-              -DENABLE_TUI_SUPPORT=0 \
-              -DCROSS_COMPILE_RPI_ARM=1 .
+          if [[ "${{ matrix.arch }}" == 'amd64' || "${{ matrix.arch }}" == 'arm' || "${{ matrix.arch }}" == 'aarch64' ]]; then
+            build_args='-DENABLE_TUI_SUPPORT=1'
           else
-            if [[ "${{ github.event_name }}" == 'amd64' ]]; then
-              cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s" \
-                -DENABLE_TUI_SUPPORT=1 \
-                -D "CROSS_COMPILE_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')=1" .
-            else             
-              cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-s" -DCMAKE_CXX_FLAGS="-s" \
-                -DENABLE_TUI_SUPPORT=0 \
-                -D "CROSS_COMPILE_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')=1" .
-            fi
+            build_args='-DENABLE_TUI_SUPPORT=0'
+          fi
+
+          build_args="$build_args -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS='-s' -DCMAKE_CXX_FLAGS='-s'"
+
+          if [[ "${{ matrix.arch }}" == 'armhf' ]]; then
+            cmake $(echo $build_args) -DCROSS_COMPILE_RPI_ARM=1 .
+          else
+            cmake $(echo $build_args) \
+              -D "CROSS_COMPILE_$(echo '${{ matrix.arch }}' | tr '[:lower:]' '[:upper:]')=1" .
           fi
 
           make -j $(nproc)
@@ -112,11 +129,10 @@ jobs:
         with:
           name: ${{ needs.setup.outputs.APPNAME }}-${{ matrix.arch }}
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.PACKAGENAME }}.tar.gz
-          asset_name: ${{ env.PACKAGENAME }}.tar.gz
-          asset_content_type: application/gzip
+          tag_name: ${{ needs.setup.outputs.VERSION }}
+          files: ${{ env.PACKAGENAME }}.tar.gz
+          append_body: true


### PR DESCRIPTION
This PR adds TUI support to `arm` and `arm64` to the `build` and `release` GitHub Actions workflows.

It also fixes deprecated `set-output` commands by moving to `softprops/action-gh-release@v1` instead of the deprecated `actions/upload-release-asset` action.