### PR TITLE
Deprecate Peer ACL blacklist mode

### DIFF
--- a/configs/fne-config.example.yml
+++ b/configs/fne-config.example.yml
@@ -253,16 +253,14 @@ system:
         time: 2
 
     #
-    # Peer whitelist and blacklist configuration
+    # Peer ACL configuration
     #
     peer_acl:
         # Flag indicating whether or not the peer ACLs are enabled.
         enable: false
-        # Peer ACL mode: whitelist or blacklist
-        mode: whitelist
-        # Full path to the white/blacklist file.
+        # Full path to the peer ACL file.
         file: peer_list.dat
-        # Amount of time between updates of white/blacklist file. (minutes)
+        # Amount of time between updates of peer ACL file. (minutes)
         time: 2
 
 #

--- a/src/common/lookups/LookupTable.h
+++ b/src/common/lookups/LookupTable.h
@@ -48,7 +48,7 @@ namespace lookups
         /**
          * @brief Initializes a new instance of the LookupTable class.
          * @param filename Full-path to the lookup table file.
-         * @param reloadTime Interval of time to reload the channel identity table.
+         * @param reloadTime Interval of time to reload the lookup table.
          */
         LookupTable(const std::string& filename, uint32_t reloadTime) :
             Thread(),

--- a/src/common/lookups/PeerListLookup.cpp
+++ b/src/common/lookups/PeerListLookup.cpp
@@ -50,8 +50,8 @@ bool PeerListLookup::m_locked = false;
 
 /* Initializes a new instance of the PeerListLookup class. */
 
-PeerListLookup::PeerListLookup(const std::string& filename, Mode mode, uint32_t reloadTime, bool peerAcl) : LookupTable(filename, reloadTime),
-    m_acl(peerAcl), m_mode(mode)
+PeerListLookup::PeerListLookup(const std::string& filename, uint32_t reloadTime, bool peerAcl) : LookupTable(filename, reloadTime),
+    m_acl(peerAcl)
 {
     /* stub */
 }
@@ -158,32 +158,7 @@ bool PeerListLookup::isPeerAllowed(uint32_t id) const
         return true; // if not enabled, allow all peers
     }
 
-    bool allowed = false;
-    if (m_mode == WHITELIST) {
-        allowed = isPeerInList(id);
-    } else if (m_mode == BLACKLIST) {
-        allowed = !isPeerInList(id);
-    }
-
-    return allowed;
-}
-
-/* Sets the mode to either WHITELIST or BLACKLIST. */
-
-void PeerListLookup::setMode(Mode mode)
-{
-    __LOCK_TABLE();
-
-    m_mode = mode;
-
-    __UNLOCK_TABLE();
-}
-
-/* Gets the current mode. */
-
-PeerListLookup::Mode PeerListLookup::getMode() const 
-{
-    return m_mode;
+    return isPeerInList(id);
 }
 
 /* Gets the entire peer ID table. */

--- a/src/common/lookups/PeerListLookup.h
+++ b/src/common/lookups/PeerListLookup.h
@@ -153,20 +153,12 @@ namespace lookups
     class HOST_SW_API PeerListLookup : public LookupTable<PeerId> {
     public:
         /**
-         * @brief Peer List Mode
-         */
-        enum Mode {
-            WHITELIST,      //! Peers listed are whitelisted
-            BLACKLIST       //! Peers listed are blacklisted
-        };
-
-        /**
          * @brief Initializes a new instance of the PeerListLookup class.
          * @param filename Full-path to the list file.
-         * @param mode Mode to operate in (WHITELIST or BLACKLIST).
-         * @param peerAcl Flag indicating if the lookup is enabled.
+         * @param reloadTime Interval of time to reload the lookup table.
+         * @param peerAcl Flag indicating these rules are enabled for enforcing access control.
          */
-        PeerListLookup(const std::string& filename, Mode mode, uint32_t reloadTime, bool peerAcl);
+        PeerListLookup(const std::string& filename, uint32_t reloadTime, bool peerAcl);
 
         /**
          * @brief Clears all entries from the list.
@@ -224,17 +216,6 @@ namespace lookups
         bool isPeerListEmpty() const { return m_table.size() == 0U; }
 
         /**
-         * @brief Sets the mode to either WHITELIST or BLACKLIST.
-         * @param mode The mode to set.
-         */
-        void setMode(Mode mode);
-        /**
-         * @brief Gets the current mode.
-         * @returns Mode Current peer list operational mode.
-         */
-        Mode getMode() const;
-
-        /**
          * @brief Gets the entire peer ID table.
          * @returns std::unordered_map<uint32_t, PeerId> 
          */
@@ -261,8 +242,6 @@ namespace lookups
         bool save() override;
 
     private:
-        Mode m_mode;
-
         static std::mutex m_mutex;  //! Mutex used for change locking.
         static bool m_locked;       //! Flag used for read locking (prevents find lookups), should be used when atomic operations (add/erase/etc) are being used.
     };

--- a/src/fne/HostFNE.cpp
+++ b/src/fne/HostFNE.cpp
@@ -394,15 +394,7 @@ bool HostFNE::readParams()
 
     std::string peerListLookupFile = systemConf["peer_acl"]["file"].as<std::string>();
     bool peerListLookupEnable = systemConf["peer_acl"]["enable"].as<bool>(false);
-    std::string peerListModeStr = systemConf["peer_acl"]["mode"].as<std::string>("whitelist");
     uint32_t peerListConfigReload = systemConf["peer_acl"]["time"].as<uint32_t>(30U);
-
-    lookups::PeerListLookup::Mode peerListMode;
-    if (peerListModeStr == "blacklist") {
-        peerListMode = lookups::PeerListLookup::BLACKLIST;
-    } else {
-        peerListMode = lookups::PeerListLookup::WHITELIST;
-    }
 
     LogInfo("Talkgroup Rule Lookups");
     LogInfo("    File: %s", talkgroupConfig.length() > 0U ? talkgroupConfig.c_str() : "None");
@@ -416,12 +408,11 @@ bool HostFNE::readParams()
     // try to load peer whitelist/blacklist
     LogInfo("Peer List Lookups");
     LogInfo("    Enabled: %s", peerListLookupEnable ? "yes" : "no");
-    LogInfo("    Mode: %s", peerListMode == lookups::PeerListLookup::BLACKLIST ? "blacklist" : "whitelist");
     LogInfo("    File: %s", peerListLookupFile.length() > 0U ? peerListLookupFile.c_str() : "None");
     if (peerListConfigReload > 0U)
         LogInfo("    Reload: %u mins", peerListConfigReload);
 
-    m_peerListLookup = new PeerListLookup(peerListLookupFile, peerListMode, peerListConfigReload, peerListLookupEnable);
+    m_peerListLookup = new PeerListLookup(peerListLookupFile, peerListConfigReload, peerListLookupEnable);
     m_peerListLookup->read();
 
     // try to load peer whitelist/blacklist

--- a/src/fne/network/RESTAPI.cpp
+++ b/src/fne/network/RESTAPI.cpp
@@ -650,7 +650,6 @@ void RESTAPI::initializeEndpoints()
     m_dispatcher.match(FNE_PUT_PEER_ADD).put(REST_API_BIND(RESTAPI::restAPI_PutPeerAdd, this));
     m_dispatcher.match(FNE_PUT_PEER_DELETE).put(REST_API_BIND(RESTAPI::restAPI_PutPeerDelete, this));
     m_dispatcher.match(FNE_GET_PEER_COMMIT).get(REST_API_BIND(RESTAPI::restAPI_GetPeerCommit, this));
-    m_dispatcher.match(FNE_GET_PEER_MODE).get(REST_API_BIND(RESTAPI::restAPI_GetPeerMode, this));
 
     m_dispatcher.match(FNE_GET_FORCE_UPDATE).get(REST_API_BIND(RESTAPI::restAPI_GetForceUpdate, this));
 
@@ -1329,43 +1328,6 @@ void RESTAPI::restAPI_GetPeerCommit(const HTTPPayload& request, HTTPPayload& rep
 
     m_peerListLookup->commit();
 
-    reply.payload(response);
-}
-
-/* */
-
-void RESTAPI::restAPI_GetPeerMode(const HTTPPayload& request, HTTPPayload& reply, const RequestMatch& match)
-{
-    if (!validateAuth(request, reply)) {
-        return;
-    }
-
-    json::object response = json::object();
-    setResponseDefaultStatus(response);
-
-    lookups::PeerListLookup::Mode mode = m_peerListLookup->getMode();
-    bool acl = m_peerListLookup->getACL();
-
-    std::string modeStr;
-
-    if (acl) {
-        switch (mode) {
-            case lookups::PeerListLookup::WHITELIST:
-                modeStr = "WHITELIST";
-                break;
-            case lookups::PeerListLookup::BLACKLIST:
-                modeStr = "BLACKLIST";
-                break;
-            default:
-                modeStr = "UNKNOWN";
-                break;
-        }
-    }
-    else {
-        modeStr = "DISABLED";
-    }
-
-    response["mode"].set<std::string>(modeStr);
     reply.payload(response);
 }
 

--- a/src/fne/network/RESTAPI.h
+++ b/src/fne/network/RESTAPI.h
@@ -269,13 +269,6 @@ private:
      * @param match HTTP request matcher.
      */
     void restAPI_GetPeerCommit(const HTTPPayload& request, HTTPPayload& reply, const network::rest::RequestMatch& match);
-    /**
-     * @brief 
-     * @param request HTTP request.
-     * @param reply HTTP reply.
-     * @param match HTTP request matcher.
-     */
-    void restAPI_GetPeerMode(const HTTPPayload& request, HTTPPayload& reply, const network::rest::RequestMatch& match);
 
     /**
      * @brief 

--- a/src/fne/network/RESTDefines.h
+++ b/src/fne/network/RESTDefines.h
@@ -43,7 +43,6 @@
 #define FNE_PUT_PEER_ADD                "/peer/add"
 #define FNE_PUT_PEER_DELETE             "/peer/delete"
 #define FNE_GET_PEER_COMMIT             "/peer/commit"
-#define FNE_GET_PEER_MODE               "/peer/mode"
 
 #define FNE_GET_FORCE_UPDATE            "/force-update"
 

--- a/src/peered/PeerEdMain.cpp
+++ b/src/peered/PeerEdMain.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
 
     g_logDisplayLevel = 0U;
 
-    g_pidLookups = new PeerListLookup(g_iniFile, PeerListLookup::WHITELIST, 0U, false);
+    g_pidLookups = new PeerListLookup(g_iniFile, 0U, false);
     g_pidLookups->read();
     LogMessage(LOG_HOST, "Loaded peer ID file: %s", g_iniFile.c_str());
 


### PR DESCRIPTION
This deprecates and removes blacklist mode for the peer ACL list. The blacklist mode, with the current implementation of the FNE makes little to no sense.