### PR TITLE
Fix incorrect check of DFSI and FSC config options

### DIFF
--- a/src/host/Host.Config.cpp
+++ b/src/host/Host.Config.cpp
@@ -750,7 +750,7 @@ bool Host::createModem()
         m_modem->setResponseHandler(MODEM_RESP_HANDLER_BIND(Host::rmtPortModemHandler, this));
     }
 
-    if (useFSCForUDP) {
+    if (m_isModemDFSI && useFSCForUDP) {
         modem::port::specialized::V24UDPPort* udpPort = dynamic_cast<modem::port::specialized::V24UDPPort*>(m_udpDFSIRemotePort);
         udpPort->openFSC();
     }


### PR DESCRIPTION
If FSC was set to true, but the modem mode was not DFSI, dvmhost would segfault.  This commit resolves that issue by adding an additional check to ensure that FSC operation is only enabled when the modem mode is set to DFSI.