### PR TITLE
bump WebSocketPP version to conform to new CMake minimum version;

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if (NOT DISABLE_WEBSOCKETS)
         FetchContent_Declare(
             WEBSOCKETPP
             GIT_REPOSITORY https://github.com/zaphoyd/websocketpp.git
-            GIT_TAG 56123c87598f8b1dd471be83ca841ceae07f95ba # 0.8.2
+            GIT_TAG 4dfe1be74e684acca19ac1cf96cce0df9eac2a2d # 0.8.2 with modified CMake version
         )
         FetchContent_MakeAvailable(WEBSOCKETPP)
         add_subdirectory(${websocketpp_SOURCE_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Bumping the git hash for the WebSocketPP (WS++) repo to include update to CMake minimum version.

On newer CMake versions, it will outright refuse to build WS++ due to the very old version specified in the CMakeLists.txt. This commit bumps the version specified by DVM to a newer git hash from the library's repo that updates the required CMake version.

I have tested it for successful build and basic execute on my workstation; but extended testing has not been performed. I don't believe anything should really change, as there have only been a couple commits since the last version we pinned and this is the only piece of code that has been changed since then, as far as I can tell.