### PR TITLE
Log corrected MI bytes in V.24/TIA DFSI LDU2 FEC-correction warning

### DIFF
--- a/src/host/modem/ModemV24.cpp
+++ b/src/host/modem/ModemV24.cpp
@@ -1888,8 +1888,13 @@ void ModemV24::convertToAirV24(const uint8_t *data, uint32_t length)
 
                         if (correctedAlgId != m_rxCall->algoId || correctedKId != m_rxCall->kId ||
                             ::memcmp(m_rxCall->LDULC, m_rxCall->MI, MI_LENGTH_BYTES) != 0) {
-                            LogWarning(LOG_MODEM, "V.24/DFSI LDU2, %d FEC corrections changed Enc Sync content, algId = $%02X (was $%02X), kId = $%04X (was $%04X)",
-                                rsErrs, correctedAlgId, m_rxCall->algoId, correctedKId, m_rxCall->kId);
+                            LogWarning(LOG_MODEM, "V.24/DFSI LDU2, %d FEC corrections changed Enc Sync content, algId = $%02X (was $%02X), kId = $%04X (was $%04X), "
+                                "MI = %02X %02X %02X %02X %02X %02X %02X %02X %02X (was %02X %02X %02X %02X %02X %02X %02X %02X %02X)",
+                                rsErrs, correctedAlgId, m_rxCall->algoId, correctedKId, m_rxCall->kId,
+                                m_rxCall->LDULC[0U], m_rxCall->LDULC[1U], m_rxCall->LDULC[2U], m_rxCall->LDULC[3U], m_rxCall->LDULC[4U],
+                                m_rxCall->LDULC[5U], m_rxCall->LDULC[6U], m_rxCall->LDULC[7U], m_rxCall->LDULC[8U],
+                                m_rxCall->MI[0U], m_rxCall->MI[1U], m_rxCall->MI[2U], m_rxCall->MI[3U], m_rxCall->MI[4U],
+                                m_rxCall->MI[5U], m_rxCall->MI[6U], m_rxCall->MI[7U], m_rxCall->MI[8U]);
                         }
 
                         m_rxCall->algoId = correctedAlgId;
@@ -2641,8 +2646,13 @@ void ModemV24::convertToAirTIA(const uint8_t *data, uint32_t length)
 
                             if (correctedAlgId != m_rxCall->algoId || correctedKId != m_rxCall->kId ||
                                 ::memcmp(m_rxCall->LDULC, m_rxCall->MI, MI_LENGTH_BYTES) != 0) {
-                                LogWarning(LOG_MODEM, "TIA/DFSI LDU2, %d FEC corrections changed Enc Sync content, algId = $%02X (was $%02X), kId = $%04X (was $%04X)",
-                                    rsErrs, correctedAlgId, m_rxCall->algoId, correctedKId, m_rxCall->kId);
+                                LogWarning(LOG_MODEM, "TIA/DFSI LDU2, %d FEC corrections changed Enc Sync content, algId = $%02X (was $%02X), kId = $%04X (was $%04X), "
+                                    "MI = %02X %02X %02X %02X %02X %02X %02X %02X %02X (was %02X %02X %02X %02X %02X %02X %02X %02X %02X)",
+                                    rsErrs, correctedAlgId, m_rxCall->algoId, correctedKId, m_rxCall->kId,
+                                    m_rxCall->LDULC[0U], m_rxCall->LDULC[1U], m_rxCall->LDULC[2U], m_rxCall->LDULC[3U], m_rxCall->LDULC[4U],
+                                    m_rxCall->LDULC[5U], m_rxCall->LDULC[6U], m_rxCall->LDULC[7U], m_rxCall->LDULC[8U],
+                                    m_rxCall->MI[0U], m_rxCall->MI[1U], m_rxCall->MI[2U], m_rxCall->MI[3U], m_rxCall->MI[4U],
+                                    m_rxCall->MI[5U], m_rxCall->MI[6U], m_rxCall->MI[7U], m_rxCall->MI[8U]);
                             }
 
                             m_rxCall->algoId = correctedAlgId;


### PR DESCRIPTION
## Summary

The V.24/TIA DFSI LDU2 FEC-correction warning (`ModemV24::convertToAirV24`/`convertToAirTIA`) logs when a Reed-Solomon correction on the Encryption Sync codeword changes `algId`, `kId`, or `MI`. The trigger condition already checked all three fields via `memcmp` against `MI`, but the log message itself only printed `algId`/`kId` — so a correction that changed *only* the MI bytes produced a warning showing no apparent difference between old and new values.

## Change

Extend both LogWarning calls (V.24 and TIA paths) to print the full 9-byte MI, before and after correction, alongside the existing `algId`/`kId` fields.

## Why this matters

MI is the encryption sync IV; on an encrypted call it should only ever advance via the expected LFSR step between LDU2s. Logging the actual before/after MI value (not just a "changed" flag) lets an operator verify a correction landed on a plausible LFSR successor rather than a false-positive correction that could desync the keystream. On unencrypted calls (`algId = $80`) the same log confirms the correction is inert. Verified against live production traffic (AWP-STGO) — example below shows a benign single-byte MI correction on a clear (unencrypted) call.

```
W: (MODEM) V.24/DFSI LDU2, 1 FEC corrections changed Enc Sync content, algId = $80 (was $80), kId = $0000 (was $0000), MI = 00 00 00 00 00 00 00 00 00 (was 00 00 00 00 00 00 00 00 01)
```

## Scope

DFSI (V.24) path only, consistent with prior FEC-correction work in this file — does not touch the direct air/RF modem path.
